### PR TITLE
Update get_eigen.Rd

### DIFF
--- a/man/get_eigen.Rd
+++ b/man/get_eigen.Rd
@@ -25,9 +25,3 @@ get_eigen(gene.mod, norm.dat, select.cells = colnames(norm.dat),
 \value{
 A list with two elements: module eigen genes, and if prefix is not NULL, dendrogram for selected cells.
 }
-\description{
-.. content for \description{} (no empty lines) ..
-}
-\details{
-.. content for \details{} ..
-}


### PR DESCRIPTION
removed description tag which generates a compilation error on R version 3.6.0 (2019-04-26) -- "Planting of a Tree"
Copyright (C) 2019 The R Foundation for Statistical Computing
Platform: x86_64-apple-darwin18.5.0 (64-bit)

Error : (converted from warning) /private/var/folders/12/x60bf0hn39x2ym16q19khxnw0000gn/T/RtmpwsvvMG/R.INSTALL85855cba9b1a/scrattch.hicat/man/get_eigen.Rd:29: unexpected section header '\description'
ERROR: installing Rd objects failed for package ‘scrattch.hicat’
* removing ‘/Users/gas361/Library/R/3.6/library/scrattch.hicat’
Error in i.p(...) :
  (converted from warning) installation of package ‘/var/folders/12/x60bf0hn39x2ym16q19khxnw0000gn/T//RtmpWET1Dr/file85292aabf8e/scrattch.hicat_0.0.16.tar.gz’ had non-zero exit status